### PR TITLE
OPTIMIZE njkRenderer.compile

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,11 @@ function njkRenderer(data, locals, callback) {
 
 // Return a compiled renderer.
 njkRenderer.compile = function (data) {
+	const compiledTemplate = njkCompile(data);
+	
 	// Need a closure to keep the compiled template.
 	return function (locals, callback) {
-		return njkCompile(data).render(locals, callback);
+		return compiledTemplate.render(locals, callback);
 	}
 }
 


### PR DESCRIPTION
keep cache of compiled template with data. Instead of recompile template each time of njkRenderer.compile